### PR TITLE
WE1 Task: add SpringDoc Open Api documentation for existing endpoints

### DIFF
--- a/api/document-service/pom.xml
+++ b/api/document-service/pom.xml
@@ -17,6 +17,8 @@
         <java.version>17</java.version>
         <sonar.organization>nhantran3395</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>
@@ -72,6 +74,11 @@
             <artifactId>postgresql</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>
@@ -112,6 +119,13 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/DocumentServiceApplication.java
+++ b/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/DocumentServiceApplication.java
@@ -1,13 +1,31 @@
 package com.nhantran.markdowneditor.documentservice;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication
+@PropertySource("classpath:META-INF/build-info.properties")
 public class DocumentServiceApplication {
+    @Value("${build.version}")
+    private String buildVersion;
 
-	public static void main(String[] args) {
-		SpringApplication.run(DocumentServiceApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(DocumentServiceApplication.class, args);
+    }
 
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(
+                        new Info()
+                                .version(buildVersion)
+                                .title("Document Service API")
+                                .description("REST API for Document Service")
+                );
+    }
 }

--- a/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/CreateDocumentController.java
+++ b/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/CreateDocumentController.java
@@ -2,6 +2,11 @@ package com.nhantran.markdowneditor.documentservice.adapter.in.web;
 
 import com.nhantran.markdowneditor.documentservice.application.port.in.CreateDocumentCommand;
 import com.nhantran.markdowneditor.documentservice.application.port.in.CreateDocumentUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,6 +17,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.net.URI;
 
 @RestController
+@Tag(name = "Documents")
 public class CreateDocumentController {
     private final CreateDocumentUseCase createDocumentUseCase;
 
@@ -20,6 +26,15 @@ public class CreateDocumentController {
     }
 
     @PostMapping("/documents")
+    @Operation(summary = "Create document")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Successful operation",
+                    content = @Content
+            ),
+            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content)
+    })
     public ResponseEntity<Void> createDocument(@RequestBody @Validated CreateDocumentCommand createDocumentCommand) {
         Long id = createDocumentUseCase.createDocument(createDocumentCommand);
         URI location = ServletUriComponentsBuilder

--- a/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/DeleteDocumentController.java
+++ b/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/DeleteDocumentController.java
@@ -1,9 +1,11 @@
 package com.nhantran.markdowneditor.documentservice.adapter.in.web;
 
 import com.nhantran.markdowneditor.documentservice.application.port.in.DeleteDocumentUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "Documents")
 public class DeleteDocumentController {
     private final DeleteDocumentUseCase deleteDocumentUseCase;
 

--- a/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/GetDocumentDetailController.java
+++ b/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/GetDocumentDetailController.java
@@ -2,6 +2,12 @@ package com.nhantran.markdowneditor.documentservice.adapter.in.web;
 
 import com.nhantran.markdowneditor.documentservice.application.domain.model.Document;
 import com.nhantran.markdowneditor.documentservice.application.port.in.GetDocumentDetailUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Optional;
 
 @RestController
+@Tag(name = "Documents")
 public class GetDocumentDetailController {
 
     private final GetDocumentDetailUseCase getDocumentDetailUseCase;
@@ -19,6 +26,16 @@ public class GetDocumentDetailController {
     }
 
     @GetMapping("documents/{documentId}")
+    @Operation(summary = "View document detail")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Successful operation",
+                    content = @Content(schema = @Schema(implementation = Document.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Document not found", content = @Content)
+    })
     public ResponseEntity<Document> getDocumentDetail(@PathVariable("documentId") Long documentId) {
         Optional<Document> document = getDocumentDetailUseCase.getDocumentDetail(documentId);
         return document.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());

--- a/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/GetDocumentPreviewsController.java
+++ b/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/GetDocumentPreviewsController.java
@@ -2,6 +2,13 @@ package com.nhantran.markdowneditor.documentservice.adapter.in.web;
 
 import com.nhantran.markdowneditor.documentservice.application.port.in.DocumentPreview;
 import com.nhantran.markdowneditor.documentservice.application.port.in.GetDocumentPreviewsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
+@Tag(name = "Documents")
 public class GetDocumentPreviewsController {
     private final GetDocumentPreviewsUseCase getDocumentPreviewsUseCase;
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -20,6 +28,15 @@ public class GetDocumentPreviewsController {
     }
 
     @GetMapping("/documents/previews")
+    @Operation(summary = "List all document previews")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Successful operation",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = DocumentPreview.class)))
+            ),
+            @ApiResponse(responseCode = "400", description = "Invalid input", content = @Content)
+    })
     public List<DocumentPreview> getDocumentPreviews(@RequestParam(name = "title", required = false) String documentTitle) {
         logger.debug("title {}", documentTitle);
         return getDocumentPreviewsUseCase.getDocumentPreviews(documentTitle);

--- a/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/UpdateDocumentController.java
+++ b/api/document-service/src/main/java/com/nhantran/markdowneditor/documentservice/adapter/in/web/UpdateDocumentController.java
@@ -1,9 +1,11 @@
 package com.nhantran.markdowneditor.documentservice.adapter.in.web;
 
 import com.nhantran.markdowneditor.documentservice.application.port.in.UpdateDocumentUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Tag(name = "Documents")
 public class UpdateDocumentController {
     private final UpdateDocumentUseCase updateDocumentUseCase;
 

--- a/api/document-service/src/main/resources/application.properties
+++ b/api/document-service/src/main/resources/application.properties
@@ -1,11 +1,19 @@
 spring.application.name=document-service
+## spring boot docker compose
 spring.docker.compose.file=api/document-service/compose.yaml
+spring.docker.compose.stop.command=down
+## spring data jpa & hibernate
 spring.jpa.hibernate.ddl-auto=none
 spring.sql.init.mode=always
-spring.docker.compose.stop.command=down
 spring.jpa.properties.hibernate.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+## spring doc open api & swagger ui
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui
+springdoc.api-docs.version=openapi_3_1
+springdoc.remove-broken-reference-definitions=false
+## logger
 logging.level.org.hibernate.SQL=debug
 logging.level.org.hibernate.type.descriptor.sql=trace
 logging.level.org.hibernate.orm.jdbc.bind=trace


### PR DESCRIPTION
#### What does this PR do?
This PR is to add Open API and Swagger UI documentation for the endpoints in Document Service

#### How is it implemented
Install and configure `springdoc-openapi-starter-webmvc-ui` (v2.5.0)

#### How can it be tested manually
Start service locally and go to `http://localhost:8080/swagger-ui` to check out the Swagger UI documentation

#### GIF or screenshot
![image](https://github.com/nhantran3395/markdown-editor/assets/50472067/468d1ca5-ebbe-4487-a9c7-6d157c65d653)
